### PR TITLE
Add support for PHP 8.1. (1.2.0 release candidate?)

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -10,20 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - 7.2
-          - 7.3
           - 7.4
-          - 8.0-rc
+          - 8.0
+          - 8.1
         composer:
           - ""
           - "--prefer-lowest"
-        include:
-          - php: 8.0-rc
-            composer: "--ignore-platform-reqs"
         exclude:
-          - php: 8.0-rc
-            composer: ""
-          - php: 8.0-rc
+          - php: 8.0
+            composer: "--prefer-lowest"
+          - php: 8.1
             composer: "--prefer-lowest"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Changelog
 
 --------
 
+## 1.2.0 - 2022-07-13
+
+### Added
+
+* [Support] Add support for PHP 8.1.
+
+### Changed
+
+* [Support] Requires composer-runtime-api ^2 
+* [Support] Drop support for PHP 7.2.
+* [Support] Drop support for PHP 7.3.
+
+--------
+
 ## 1.1.0 - 2020-10-04
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.2
+ARG PHP_VERSION=7.4
 FROM php:${PHP_VERSION}-cli
 
 # Install pickle to help manage extensions
@@ -10,8 +10,9 @@ ARG COVERAGE
 RUN if [ "$COVERAGE" = "pcov" ]; then pickle install pcov && docker-php-ext-enable pcov; fi
 
 # Install composer to manage PHP dependencies
-RUN curl https://getcomposer.org/download/1.10.13/composer.phar -o /usr/local/sbin/composer
-RUN chmod +x /usr/local/sbin/composer
-RUN composer self-update
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+ && php composer-setup.php --2.2 \
+ && mv composer.phar /usr/local/bin/composer \
+ && chmod +x /usr/local/bin/composer 
 
 WORKDIR /app

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,15 @@
     }],
     "require": {
         "ext-mbstring": "*",
-        "php": "^7.2 || ^8.0"
+        "php": "^7.4 || ^8.0",
+        "composer-runtime-api": "^2"
     },
     "require-dev": {
-        "maglnet/composer-require-checker": "^2.0",
-        "phpstan/phpstan": "^0.11.7",
-        "squizlabs/php_codesniffer": "^3.4",
-        "phpunit/phpunit": "^8.1"
+        "maglnet/composer-require-checker": "^3.0 || ^4.0",
+        "phpstan/phpstan": "^1.0",
+        "squizlabs/php_codesniffer": "^3.5",
+        "phpunit/phpunit": "^8.1",
+        "rector/rector": "^0.13.8"
     },
     "autoload": {
         "psr-4": {"duncan3dc\\Bom\\": "src/"}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
 parameters:
   ignoreErrors:
     - '/^Access to an undefined property object::\$data(len)?\.$/'
+  reportUnmatchedIgnoredErrors: false
+

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src'
+    ]);
+
+    // register a single rule
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    //define sets of rules
+    $rectorConfig->sets([
+    	LevelSetList::UP_TO_PHP_81
+    ]);
+};

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -15,7 +15,7 @@ class Handler
     /**
      * @var string $encoding The encoding that the data we're handling is in.
      */
-    private $encoding;
+    private ?string $encoding = null;
 
 
     /**
@@ -53,8 +53,6 @@ class Handler
      * Read some data, remove any BOM found, and convert to UTF-8.
      *
      * @param string $string The data to read/convert
-     *
-     * @return string
      */
     public function convert(string $string): string
     {

--- a/src/StreamFilter.php
+++ b/src/StreamFilter.php
@@ -10,7 +10,7 @@ class StreamFilter extends \php_user_filter
     /**
      * @var Handler $handler The bom handler instance.
      */
-    private $handler;
+    private \duncan3dc\Bom\Handler $handler;
 
 
     public function onCreate(): bool

--- a/src/Util.php
+++ b/src/Util.php
@@ -4,13 +4,10 @@ namespace duncan3dc\Bom;
 
 class Util
 {
-
     /**
      * Remove a BOM from a file contents and convert to UTF-8.
      *
      * @param string $string The file contents to convert
-     *
-     * @return string
      */
     public static function removeBom(string $string): string
     {

--- a/tests/StreamFilterTest.php
+++ b/tests/StreamFilterTest.php
@@ -17,7 +17,6 @@ use function stream_filter_register;
 
 class StreamFilterTest extends TestCase
 {
-
     public static function setUpBeforeClass(): void
     {
         stream_filter_register("bom-filter", StreamFilter::class);

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -10,7 +10,6 @@ use function is_string;
 
 class UtilTest extends TestCase
 {
-
     public function fileProvider(): \Generator
     {
         $files = glob(__DIR__ . "/files/*.csv") ?: [];


### PR DESCRIPTION
- Requires composer-runtime-api ^2.
- Drop support for PHP 7.2.
- Drop support for PHP 7.3.